### PR TITLE
Fix issue #7

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -186,6 +186,12 @@ class S3Storage(Storage):
         response = self.connection.delete(self.bucket, name)
         if response.http_response.status != 204:
             raise IOError("S3StorageError: %s" % response.message)
+        else:
+            # If deletion succeeded remove the file from `self.entries` as well
+            try:
+                del self.entries[name]
+            except KeyError:
+                pass
 
     def exists(self, name):
         name = self._clean_name(name)


### PR DESCRIPTION
This is a proposed fix for issue #7.

If the S3 delete succeeds, we try to remove the file from `S3Storage.entries`, if it exists.
