### PR TITLE
Fixes a conflict with easy_thumbnails's thumbnail generation

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -397,7 +397,9 @@ class S3BotoStorageFile(File):
 
     def _get_file(self):
         if self._file is None:
-            self._file = BytesIO()
+            self._file = StringIO()
+            if 'rb' == self._mode:
+                self._file = BytesIO()
             if 'r' in self._mode:
                 self._is_dirty = False
                 self.key.get_contents_to_file(self._file)

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -2,9 +2,9 @@ import os
 import mimetypes
 
 try:
-    from io import StringIO
+    from io import StringIO, BytesIO
 except ImportError:
-    from io import StringIO  # noqa
+    from io import StringIO, BytesIO  # noqa
 
 from django.conf import settings
 from django.core.files.base import File
@@ -397,7 +397,7 @@ class S3BotoStorageFile(File):
 
     def _get_file(self):
         if self._file is None:
-            self._file = StringIO()
+            self._file = BytesIO()
             if 'r' in self._mode:
                 self._is_dirty = False
                 self.key.get_contents_to_file(self._file)


### PR DESCRIPTION
This error is fixed:

```
File ".../site-packages/easy_thumbnails/source_generators.py", line 30, in pil_image
    source = BytesIO(source.read())
TypeError: 'str' does not support the buffer interface
```
